### PR TITLE
Make IRO consistent

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "5ff06aa9d4d474924437add182099207b5b7f5f7"
+commit-id = "ff37be82c6e4d7c4f0f96f4937f2d14d1aadae67"
 
 [python]
 with-appveyor = false
@@ -13,6 +13,10 @@ with-sphinx-doctests = false
 
 [tox]
 use-flake8 = true
+testenv-additional = [
+    "setenv =",
+    "    ZOPE_INTERFACE_STRICT_IRO=1",
+    ]
 
 [coverage]
 fail-under = 93

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,8 @@ Changes
 - Fix compatibility with ``zope.component >= 5`` and newer versions of other
   dependencies.
 
+- Fix inconsistent IRO.
+
 - Drop support for Python 3.4.
 
 3.0.1 (2018-01-15)

--- a/src/grokcore/rest/interfaces.py
+++ b/src/grokcore/rest/interfaces.py
@@ -26,8 +26,8 @@ import grokcore.view.interfaces
 
 class IBaseClasses(
         grokcore.component.interfaces.IBaseClasses,
-        grokcore.view.interfaces.IBaseClasses,
-        grokcore.security.interfaces.IBaseClasses):
+        grokcore.security.interfaces.IBaseClasses,
+        grokcore.view.interfaces.IBaseClasses):
 
     REST = interface.Attribute("Base class for REST views.")
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,8 @@ commands =
     zope-testrunner --test-path=src {posargs:-vc}
 extras =
     test
+setenv =
+    ZOPE_INTERFACE_STRICT_IRO=1
 
 [testenv:lint]
 basepython = python3


### PR DESCRIPTION
Fix IRO and check for it. (Based on branch of @janjaapdriessen.)

Without the `@implementer` directive I get an error that at least one interface must be implemented.
With `zope.interface.Interface` I get an inconsistent IRO.
So I decided to use a common interface but had to adapt the code to it.
