### PR TITLE
Drop support for Python 3.5 and 2.7 + add support for 3.10

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,7 +28,7 @@ max_line_length = off
 # 4 space indentation
 indent_size = 4
 
-[*.{yml,zpt,pt,dtml}]
+[*.{yml,zpt,pt,dtml,zcml}]
 # 2 space indentation
 indent_size = 2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,20 +16,21 @@ jobs:
       # We want to see all failures:
       fail-fast: false
       matrix:
+        os:
+        - ubuntu
         config:
         # [Python version, tox env]
-        - ["3.8",   "lint"]
-        - ["2.7",   "py27"]
-        - ["3.5",   "py35"]
+        - ["3.9",   "lint"]
         - ["3.6",   "py36"]
         - ["3.7",   "py37"]
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]
-        - ["pypy2", "pypy"]
-        - ["pypy3", "pypy3"]
-        - ["3.8",   "coverage"]
+        - ["3.10",  "py310"]
+        - ["pypy-3.7", "pypy3"]
+        - ["3.9",   "coverage"]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
     - uses: actions/checkout@v2
@@ -54,7 +55,7 @@ jobs:
     - name: Coverage
       if: matrix.config[1] == 'coverage'
       run: |
-        pip install coveralls coverage-python-version
+        pip install coveralls
         coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
+*.dll
 *.egg-info/
 *.profraw
 *.pyc
 *.pyo
+*.so
 .coverage
 .coverage.*
 .eggs/
@@ -26,4 +28,5 @@ lib64
 log/
 parts/
 pyvenv.cfg
+testing.log
 var/

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,14 +2,14 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "a42b1792f61e841423b04385d644c7e2d4581c1c"
+commit-id = "ae61f414cfef4e129d275679c6a76dc67b1a2c11"
 
 [python]
-with-appveyor = false
 with-pypy = true
-with-legacy-python = true
-with-docs = false
+with-legacy-python = false
 with-sphinx-doctests = false
+with-windows = false
+with-future-python = false
 
 [tox]
 use-flake8 = true

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,10 +2,12 @@
 Changes
 =======
 
-3.1.1 (unreleased)
-==================
+4.0 (unreleased)
+================
 
-- Nothing changed yet.
+- Drop support for Python 2.7 and 3.5.
+
+- Add support for Python 3.10.
 
 
 3.1.0 (2021-04-07)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+<!--
+Generated from:
+https://github.com/zopefoundation/meta/tree/master/config/pure-python
+--> 
+# Contributing to zopefoundation projects
+
+The projects under the zopefoundation GitHub organization are open source and
+welcome contributions in different forms:
+
+* bug reports
+* code improvements and bug fixes
+* documentation improvements
+* pull request reviews
+
+For any changes in the repository besides trivial typo fixes you are required
+to sign the contributor agreement. See
+https://www.zope.dev/developer/becoming-a-committer.html for details.
+
+Please visit our [Developer
+Guidelines](https://www.zope.dev/developer/guidelines.html) if you'd like to
+contribute code changes and our [guidelines for reporting
+bugs](https://www.zope.dev/developer/reporting-bugs.html) if you want to file a
+bug report.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
+include *.md
 include *.rst
 include *.txt
 include buildout.cfg

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [bdist_wheel]
-universal = 1
+universal = 0
 
 [flake8]
 doctests = 1
@@ -15,3 +15,14 @@ per-file-ignores =
 ignore =
     .editorconfig
     .meta.toml
+
+[isort]
+force_single_line = True
+combine_as_imports = True
+sections = FUTURE,STDLIB,THIRDPARTY,ZOPE,FIRSTPARTY,LOCALFOLDER
+known_third_party = six, docutils, pkg_resources
+known_zope =
+known_first_party =
+default_section = ZOPE
+line_length = 79
+lines_after_imports = 2

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
-from setuptools import setup, find_packages
 import os
+
+from setuptools import find_packages
+from setuptools import setup
 
 
 def read(*rnames):
@@ -31,7 +33,7 @@ tests_require = [
 
 setup(
     name='grokcore.rest',
-    version='3.1.1.dev0',
+    version='4.0.dev0',
     author='Grok Team',
     author_email='grok-dev@zope.org',
     url='http://grok.zope.org',
@@ -44,14 +46,13 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Zope Public License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
@@ -62,6 +63,7 @@ setup(
     namespace_packages=['grokcore'],
     include_package_data=True,
     zip_safe=False,
+    python_requires='>= 3.6',
     install_requires=[
         'grokcore.component >= 2.5dev',
         'grokcore.security',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ tests_require = [
     'grokcore.content',
     'grokcore.view[security_publication]',
     'grokcore.view[test]',
-    'six',
     'zope.app.appsetup',
     'zope.app.wsgi[test]',
     'zope.errorview >= 1.2.0',

--- a/src/grokcore/rest/__init__.py
+++ b/src/grokcore/rest/__init__.py
@@ -15,11 +15,14 @@
 from grokcore.component import *
 from grokcore.security import *
 from grokcore.view import *
+from zope.interface import moduleProvides
+
+from grokcore.rest.components import REST
+from grokcore.rest.directive import restskin
 from grokcore.rest.interfaces import IREST
 from grokcore.rest.interfaces import IRESTLayer
 from grokcore.rest.interfaces import IRESTSkinType
-from grokcore.rest.components import REST
-from grokcore.rest.directive import restskin
-from zope.interface import moduleProvides
+
+
 moduleProvides(IREST)
 __all__ = list(IREST)

--- a/src/grokcore/rest/components.py
+++ b/src/grokcore/rest/components.py
@@ -19,9 +19,9 @@ provided here.
 
 """
 import zope.location
-
-from zope import interface
 from grokcore.view import ViewSupport
+from zope import interface
+
 from grokcore.rest.interfaces import IREST
 
 

--- a/src/grokcore/rest/interfaces.py
+++ b/src/grokcore/rest/interfaces.py
@@ -13,15 +13,13 @@
 ##############################################################################
 """Grok interfaces
 """
-from zope import interface
-from zope.interface.interfaces import IInterface
-
-
 # Expose interfaces from grokcore.* packages as well:
 import grokcore.component.interfaces
-import grokcore.traverser.interfaces
 import grokcore.security.interfaces
+import grokcore.traverser.interfaces
 import grokcore.view.interfaces
+from zope import interface
+from zope.interface.interfaces import IInterface
 
 
 class IBaseClasses(

--- a/src/grokcore/rest/meta.py
+++ b/src/grokcore/rest/meta.py
@@ -21,16 +21,16 @@ and available as `martian` recursively examines the packages and modules
 of a Grok-based web application.
 
 """
+import grokcore.component
+import grokcore.security
+import grokcore.view
+import martian
+from grokcore.view import make_checker
 from martian.error import GrokError
 from zope import interface
-from grokcore.view import make_checker
 from zope.interface.interface import InterfaceClass
 
-import martian
 import grokcore.rest
-import grokcore.component
-import grokcore.view
-import grokcore.security
 
 
 class RESTGrokker(martian.MethodGrokker):

--- a/src/grokcore/rest/publication.py
+++ b/src/grokcore/rest/publication.py
@@ -23,17 +23,15 @@ end of the traversal process is, in fact, permitted to display the
 object.
 
 """
-from grokcore.rest.rest import GrokMethodNotAllowed
 from grokcore.view.publication import ZopePublicationSansProxy
-
 from zope import component
-from zope.security.checker import selectChecker
-from zope.publisher.publish import mapply
-from zope.publisher.interfaces.http import IHTTPException
-
 from zope.app.publication.http import HTTPPublication
-from zope.app.publication.requestpublicationfactories import (
-    HTTPFactory)
+from zope.app.publication.requestpublicationfactories import HTTPFactory
+from zope.publisher.interfaces.http import IHTTPException
+from zope.publisher.publish import mapply
+from zope.security.checker import selectChecker
+
+from grokcore.rest.rest import GrokMethodNotAllowed
 
 
 class GrokHTTPPublication(ZopePublicationSansProxy, HTTPPublication):

--- a/src/grokcore/rest/publication.py
+++ b/src/grokcore/rest/publication.py
@@ -75,5 +75,5 @@ class GrokHTTPFactory(HTTPFactory):
     """
 
     def __call__(self):
-        request, publication = super(GrokHTTPFactory, self).__call__()
+        request, publication = super().__call__()
         return request, GrokHTTPPublication

--- a/src/grokcore/rest/rest.py
+++ b/src/grokcore/rest/rest.py
@@ -6,18 +6,20 @@ been defined.  These all return the HTTP response Method Not Allowed.
 
 """
 import grokcore.component as grok
-import grokcore.rest
 import grokcore.view
-from grokcore.rest.interfaces import IRESTSkinType
-
 from zope import component
 from zope.browser.interfaces import IView
-from zope.interface import Interface, implementer
+from zope.interface import Interface
+from zope.interface import implementer
 from zope.interface.interfaces import ComponentLookupError
 from zope.publisher.browser import applySkin
-from zope.publisher.interfaces.http import IHTTPRequest, MethodNotAllowed
+from zope.publisher.interfaces.http import IHTTPRequest
+from zope.publisher.interfaces.http import MethodNotAllowed
 from zope.traversing.interfaces import TraversalError
 from zope.traversing.namespace import view
+
+import grokcore.rest
+from grokcore.rest.interfaces import IRESTSkinType
 
 
 class GrokMethodNotAllowed(MethodNotAllowed):

--- a/src/grokcore/rest/testing.py
+++ b/src/grokcore/rest/testing.py
@@ -13,8 +13,8 @@
 ##############################################################################
 """Grok test helpers
 """
-from zope.configuration.config import ConfigurationMachine
 from grokcore.component import zcml
+from zope.configuration.config import ConfigurationMachine
 
 
 def grok(module_name):

--- a/src/grokcore/rest/testing.py
+++ b/src/grokcore/rest/testing.py
@@ -25,13 +25,3 @@ def grok(module_name):
     zcml.do_grok('grokcore.rest.meta', config)
     zcml.do_grok(module_name, config)
     config.execute_actions()
-
-
-def bprint(data):
-    """Python 2 and 3 doctest compatible print.
-
-    http://python3porting.com/problems.html#string-representation
-    """
-    if not isinstance(data, str):
-        data = data.decode()
-    print(data.strip())

--- a/src/grokcore/rest/tests/__init__.py
+++ b/src/grokcore/rest/tests/__init__.py
@@ -15,11 +15,14 @@
 from grokcore.component import *
 from grokcore.security import *
 from grokcore.view import *
+from zope.interface import moduleProvides
+
+from grokcore.rest.components import REST
+from grokcore.rest.directive import restskin
 from grokcore.rest.interfaces import IREST
 from grokcore.rest.interfaces import IRESTLayer
 from grokcore.rest.interfaces import IRESTSkinType
-from grokcore.rest.components import REST
-from grokcore.rest.directive import restskin
-from zope.interface import moduleProvides
+
+
 moduleProvides(IREST)
 __all__ = list(IREST)

--- a/src/grokcore/rest/tests/functional/rest/localgrants.py
+++ b/src/grokcore/rest/tests/functional/rest/localgrants.py
@@ -48,7 +48,11 @@ ILocation and has the appropriate parent pointer:
 
 """
 import grokcore.component as grok
-from grokcore import view, content, rest, security
+
+from grokcore import content
+from grokcore import rest
+from grokcore import security
+from grokcore import view
 
 
 class Mammoth(content.Model):

--- a/src/grokcore/rest/tests/functional/rest/rest.py
+++ b/src/grokcore/rest/tests/functional/rest/rest.py
@@ -312,8 +312,13 @@ Todo:
 """  # noqa: E501 line too long
 
 import grokcore.component as grok
-from grokcore import rest, view, security, content
-from zope.interface import Interface, implementer
+from zope.interface import Interface
+from zope.interface import implementer
+
+from grokcore import content
+from grokcore import rest
+from grokcore import security
+from grokcore import view
 
 
 class IFoo(Interface):

--- a/src/grokcore/rest/tests/functional/rest/rest.py
+++ b/src/grokcore/rest/tests/functional/rest/rest.py
@@ -21,40 +21,40 @@ Let's create a simple application with REST support::
 Issue a GET request::
 
   >>> response = http_call(wsgi_app(), 'GET', 'http://localhost/++rest++a/app')
-  >>> bprint(response.getBody())
-  GET
+  >>> print(response.getBody())
+  b'GET'
 
 Issue a POST request::
 
   >>> response = http_call(wsgi_app(), 'POST', 'http://localhost/++rest++a/app')
-  >>> bprint(response.getBody())
-  POST
+  >>> print(response.getBody())
+  b'POST'
 
 Issue a PUT request::
 
   >>> response = http_call(wsgi_app(), 'PUT', 'http://localhost/++rest++a/app')
-  >>> bprint(response.getBody())
-  PUT
+  >>> print(response.getBody())
+  b'PUT'
 
 Issue a DELETE request::
 
   >>> response = http_call(wsgi_app(), 'DELETE', 'http://localhost/++rest++a/app')
-  >>> bprint(response.getBody())
-  DELETE
+  >>> print(response.getBody())
+  b'DELETE'
 
 Let's examine a rest protocol b which has no POST or DELETE request defined::
 
 The GET request works as expected::
 
   >>> response = http_call(wsgi_app(), 'GET', 'http://localhost/++rest++b/app')
-  >>> bprint(response.getBody())
-  GET
+  >>> print(response.getBody())
+  b'GET'
 
 So does the PUT request::
 
   >>> response = http_call(wsgi_app(), 'PUT', 'http://localhost/++rest++b/app')
-  >>> bprint(response.getBody())
-  PUT
+  >>> print(response.getBody())
+  b'PUT'
 
 POST is not defined, however, and we should get a 405 (Method not
 allowed) error::
@@ -125,8 +125,8 @@ We have added support for GET for the ``alpha`` subobject only, in
 the default rest layer::
 
   >>> response = http_call(wsgi_app(), 'GET', 'http://localhost/++rest++d/app/alpha')
-  >>> bprint(response.getBody())
-  GET2
+  >>> print(response.getBody())
+  b'GET2'
 
 But not for POST::
 
@@ -271,38 +271,38 @@ case, but a more specific REST view is declared on the class itself::
 We should get a different result for the GET request::
 
   >>> response = http_call(wsgi_app(), 'GET', 'http://localhost/++rest++g/app/one')
-  >>> bprint(response.getBody())
-  GET interface registered
+  >>> print(response.getBody())
+  b'GET interface registered'
   >>> response = http_call(wsgi_app(), 'GET', 'http://localhost/++rest++g/app/two')
-  >>> bprint(response.getBody())
-  GET directly registered
+  >>> print(response.getBody())
+  b'GET directly registered'
 
 We should also get a different result for the PUT request::
 
   >>> response = http_call(wsgi_app(), 'PUT', 'http://localhost/++rest++g/app/one')
-  >>> bprint(response.getBody())
-  PUT interface registered
+  >>> print(response.getBody())
+  b'PUT interface registered'
   >>> response = http_call(wsgi_app(), 'PUT', 'http://localhost/++rest++g/app/two')
-  >>> bprint(response.getBody())
-  PUT directly registered
+  >>> print(response.getBody())
+  b'PUT directly registered'
 
 We expect POST and DELETE to be the same on both. For the directly
 registered object (two) it should fall back to the interface as there
 is none more specifically declared::
 
   >>> response = http_call(wsgi_app(), 'POST', 'http://localhost/++rest++g/app/one')
-  >>> bprint(response.getBody())
-  POST interface registered
+  >>> print(response.getBody())
+  b'POST interface registered'
   >>> response = http_call(wsgi_app(), 'POST', 'http://localhost/++rest++g/app/two')
-  >>> bprint(response.getBody())
-  POST interface registered
+  >>> print(response.getBody())
+  b'POST interface registered'
 
   >>> response = http_call(wsgi_app(), 'DELETE', 'http://localhost/++rest++g/app/one')
-  >>> bprint(response.getBody())
-  DELETE interface registered
+  >>> print(response.getBody())
+  b'DELETE interface registered'
   >>> response = http_call(wsgi_app(), 'DELETE', 'http://localhost/++rest++g/app/two')
-  >>> bprint(response.getBody())
-  DELETE interface registered
+  >>> print(response.getBody())
+  b'DELETE interface registered'
 
 Todo:
 

--- a/src/grokcore/rest/tests/test_functional.py
+++ b/src/grokcore/rest/tests/test_functional.py
@@ -1,7 +1,6 @@
 import doctest
 import unittest
 
-import six
 from pkg_resources import resource_listdir
 
 import zope.app.wsgi.testlayer
@@ -31,16 +30,15 @@ def http_call(app, method, path, data=None, handle_errors=False, **kw):
     """
     if path.startswith('http://localhost'):
         path = path[len('http://localhost'):]
-    request_string = '{} {} HTTP/1.1\n'.format(method, path)
+    request_string = f'{method} {path} HTTP/1.1\n'
     for key, value in kw.items():
-        request_string += '{}: {}\n'.format(key, value)
+        request_string += f'{key}: {value}\n'
     if data is not None:
-        request_string += 'Content-Length:{}\n'.format(len(data))
+        request_string += f'Content-Length:{len(data)}\n'
         request_string += '\r\n'
         request_string += data
 
-    if six.PY3:  # pragma: PY3
-        request_string = request_string.encode()
+    request_string = request_string.encode()
 
     result = http(app, request_string, handle_errors=handle_errors)
     return result
@@ -54,7 +52,7 @@ def str_http_call(*args, **kw):
 
 def suiteFromPackage(name):
     layer_dir = 'functional'
-    files = resource_listdir(__name__, '{}/{}'.format(layer_dir, name))
+    files = resource_listdir(__name__, f'{layer_dir}/{name}')
     suite = unittest.TestSuite()
     for filename in files:
         if not filename.endswith('.py'):
@@ -62,12 +60,11 @@ def suiteFromPackage(name):
         if filename == '__init__.py':
             continue
 
-        dottedname = 'grokcore.rest.tests.%s.%s.%s' % (
+        dottedname = 'grokcore.rest.tests.{}.{}.{}'.format(
             layer_dir, name, filename[:-3])
         test = doctest.DocTestSuite(
             dottedname,
             extraglobs=dict(
-                bprint=grokcore.rest.testing.bprint,
                 getRootFolder=layer.getRootFolder,
                 http_call=http_call,
                 str_http_call=str_http_call,

--- a/src/grokcore/rest/tests/test_functional.py
+++ b/src/grokcore/rest/tests/test_functional.py
@@ -1,13 +1,15 @@
 import doctest
-import grokcore.rest
-import grokcore.rest.testing
-import six
 import unittest
+
+import six
+from pkg_resources import resource_listdir
+
 import zope.app.wsgi.testlayer
 import zope.testbrowser.wsgi
-
-from pkg_resources import resource_listdir
 from zope.app.wsgi.testlayer import http
+
+import grokcore.rest
+import grokcore.rest.testing
 
 
 class Layer(

--- a/tox.ini
+++ b/tox.ini
@@ -4,20 +4,17 @@
 minversion = 3.18
 envlist =
     lint
-    py27
-    py35
     py36
     py37
     py38
     py39
-    pypy
+    py310
     pypy3
     coverage
 
 [testenv]
 usedevelop = true
 deps =
-    zope.testrunner
 commands =
     zope-testrunner --test-path=src {posargs:-vc}
 extras =
@@ -28,14 +25,25 @@ setenv =
 [testenv:lint]
 basepython = python3
 skip_install = true
-deps =
-    flake8
-    check-manifest
-    check-python-versions
 commands =
+    isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py
     flake8 src setup.py
     check-manifest
     check-python-versions
+deps =
+    check-manifest
+    check-python-versions >= 0.19.1
+    wheel
+    flake8
+    isort
+
+[testenv:isort-apply]
+basepython = python3
+commands_pre =
+deps =
+    isort
+commands =
+    isort {toxinidir}/src {toxinidir}/setup.py []
 
 [testenv:coverage]
 basepython = python3
@@ -43,8 +51,6 @@ allowlist_externals =
     mkdir
 deps =
     coverage
-    coverage-python-version
-    zope.testrunner
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}
@@ -53,8 +59,7 @@ commands =
 
 [coverage:run]
 branch = True
-plugins = coverage_python_version
-source = src
+source = grokcore.rest
 
 [coverage:report]
 precision = 2


### PR DESCRIPTION
* isort imports

This is needed because tests are broken in GHA for Python 2.7 and PyPy2 and I do not want to invest any time to find the cause and fix them. Deleting is way easier.